### PR TITLE
PHP8 support fix

### DIFF
--- a/index.php
+++ b/index.php
@@ -66,11 +66,12 @@ elseif($CONFIG['pb_infinity'] && !$CONFIG['pb_infinity_default'])
 		(array)$infinity);
 
 
-if(get_magic_quotes_gpc())
+// get_magic_quotes_gpc() Removed in PHP 8.0, deprecated since 7.4
+if(version_compare(PHP_VERSION, '8.0.0', '<') === true && function_exists(get_magic_quotes_gpc()) === true)
 {
 	function callback_stripslashes(&$val, $name) 
 	{
-		if(get_magic_quotes_gpc()) 
+		if(get_magic_quotes_gpc() === true) 
  			$val = stripslashes($val);
 	}
 


### PR DESCRIPTION
get_magic_quotes_gpc() is removed in PHP8 (deprecated since 7.4), causing a PHP8 setup to throw a fatal.

Edit: Just realized this needs a lot of mysql refactoring also (I've been using flatfile), so depending on the attention this PR gets I may include a re-do of the DB related code also, else I'll make that a separate PR.